### PR TITLE
PHP logs to stderr, adds php8.1-gmp for Web3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,13 @@
 FROM debian:bullseye-slim
 
-LABEL maintainer="Colin Wilson colin@wyveo.com"
+LABEL maintainer="Arthur Kepler kepler@partavate.com"
+# Based on wyveo/nginx-php-fpm, license MIT
 
 # Let the container know that there is no tty
 ENV DEBIAN_FRONTEND noninteractive
 ENV NGINX_VERSION 1.21.6-1~bullseye
 ENV php_conf /etc/php/8.1/fpm/php.ini
+ENV fpm_global_conf /etc/php/8.1/fpm/php-fpm.conf
 ENV fpm_conf /etc/php/8.1/fpm/pool.d/www.conf
 ENV COMPOSER_VERSION 2.2.7
 
@@ -52,6 +54,7 @@ RUN buildDeps='curl gcc make autoconf libc-dev zlib1g-dev pkg-config' \
             php8.1-readline \
             php8.1-mbstring \
             php8.1-curl \
+            php8.1-gmp \
             php8.1-gd \
             php8.1-imagick \
             php8.1-mysql \
@@ -72,7 +75,9 @@ RUN buildDeps='curl gcc make autoconf libc-dev zlib1g-dev pkg-config' \
     && sed -i -e "s/upload_max_filesize\s*=\s*2M/upload_max_filesize = 100M/g" ${php_conf} \
     && sed -i -e "s/post_max_size\s*=\s*8M/post_max_size = 100M/g" ${php_conf} \
     && sed -i -e "s/variables_order = \"GPCS\"/variables_order = \"EGPCS\"/g" ${php_conf} \
-    && sed -i -e "s/;daemonize\s*=\s*yes/daemonize = no/g" /etc/php/8.1/fpm/php-fpm.conf \
+    && sed -i -e "s/;error_log\s*=\s*syslog/error_log = \/proc\/self\/fd\/2/g" ${php_conf} \
+    && sed -i -e "s/;*\s*error_log\s*=.*/error_log = \/proc\/self\/fd\/2/g" ${fpm_global_conf} \
+    && sed -i -e "s/;daemonize\s*=\s*yes/daemonize = no/g" ${fpm_global_conf} \
     && sed -i -e "s/;catch_workers_output\s*=\s*yes/catch_workers_output = yes/g" ${fpm_conf} \
     && sed -i -e "s/pm.max_children = 5/pm.max_children = 4/g" ${fpm_conf} \
     && sed -i -e "s/pm.start_servers = 2/pm.start_servers = 3/g" ${fpm_conf} \

--- a/README.md
+++ b/README.md
@@ -4,7 +4,11 @@
 
 `Partavate-Studios/nginx-php-fpm` was forked from [`wyveo/nginx-php-fpm`](https://github.com/wyveo/nginx-php-fpm) on 2022.04.06.
 
-This only adds the `php8.1-gmp` package, (GNU Multiple Precision) which is required for working with 256-bit EVM integers.
+This fork contains the following changes:
+
+* Adds the `php8.1-gmp` Apt package, (GNU Multiple Precision) which is required for working with 256-bit EVM integers.
+* Configures PHP-FPM to log to `stderr`, for use of Kubernetes native logging.
+* Supervisord's invocation of `php-fpm` uses `/etc/php/8.1/fpm/php-fpm.conf` as its config (The original default, which still includes `pool.d/www.conf`)
 
 ## Introduction
 This is a Dockerfile to build a debian based container image running nginx and php-fpm 8.1.x / 8.0.x / 7.4.x / 7.3.x / 7.2.x / 7.1.x / 7.0.x & Composer.
@@ -22,6 +26,9 @@ This is a Dockerfile to build a debian based container image running nginx and p
 | php70 | php70 Branch |1.21.6 | 7.0.33 | buster | 2.0.13 |
 
 ## Building from source
+
+(Version PHP 8.1)
+
 To build from source you need to clone the git repo and run docker build:
 ```
 $ git clone https://github.com/Partavate-Studios/nginx-php-fpm.git
@@ -30,7 +37,7 @@ $ cd nginx-php-fpm
 
 followed by
 ```
-$ docker build -t nginx-php-fpm:php81 -t registry.gitlab.com/partavate/infrastructure/nginx-php-fpm:php81 . . # PHP 8.1.x
+$ docker build -t nginx-php-fpm:php81 -t registry.gitlab.com/partavate/infrastructure/nginx-php-fpm:php81 .
 $ docker push registry.gitlab.com/partavate/infrastructure/nginx-php-fpm:php81
 ```
 
@@ -47,9 +54,6 @@ To run the container:
 $ sudo docker run -d registry.gitlab.com/partavate/infrastructure/nginx-php-fpm:php81
 ```
 
-Default web root:
-```
-/usr/share/nginx/html
-```
+The Nginx package's pre-installed document_root is `/usr/share/nginx/html`. 
 
-Note that applications using this image should configure Nginx to use the standard web root of `/var/www/public`.
+However web applications using this base image should configure Nginx to use the document_root of `/var/www/public`.

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -24,7 +24,7 @@ supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
 serverurl=unix:///tmp/supervisor.sock ; use a unix:// URL  for a unix socket
 
 [program:php-fpm8]
-command=/usr/sbin/php-fpm8.1 --nodaemonize --fpm-config=/etc/php/8.1/fpm/pool.d/www.conf
+command=/usr/sbin/php-fpm8.1
 autostart=true
 autorestart=true
 priority=5


### PR DESCRIPTION
`Partavate-Studios/nginx-php-fpm` was forked from [`wyveo/nginx-php-fpm`](https://github.com/wyveo/nginx-php-fpm) on 2022.04.06.

This fork contains the following changes:

* Adds the `php8.1-gmp` Apt package, (GNU Multiple Precision) which is required for working with 256-bit EVM integers.
* Configures PHP-FPM to log to `stderr`, for use of Kubernetes native logging.
* Supervisord's invocation of `php-fpm` uses `/etc/php/8.1/fpm/php-fpm.conf` as its config (The original default, which still includes `pool.d/www.conf`)